### PR TITLE
fix: remove reference to our dev repo

### DIFF
--- a/setup/catalogs/data/airbyte.yaml
+++ b/setup/catalogs/data/airbyte.yaml
@@ -41,7 +41,7 @@ spec:
   catalogRef:
     name: data-engineering
   scmConnectionRef:
-    name: plural  # you'll need to add this ScmConnection manually before this is functional
+    name: github  # you'll need to add this ScmConnection manually before this is functional
   title: "Setting up airbyte on cluster {{ context.cluster }} for {{ context.cloud }}"
   message: |
     Set up airbyte on {{ context.cluster }} ({{ context.cloud }})

--- a/setup/catalogs/data/dagster.yaml
+++ b/setup/catalogs/data/dagster.yaml
@@ -37,7 +37,7 @@ spec:
   catalogRef:
     name: data-engineering
   scmConnectionRef:
-    name: plural  # you'll need to add this ScmConnection manually before this is functional
+    name: github  # you'll need to add this ScmConnection manually before this is functional
   title: Dagster setup ({{ context.cluster }})
   message: Sets up Dagster on {{ context.cluster }} cluster.
   configuration:

--- a/setup/catalogs/data/mlflow.yaml
+++ b/setup/catalogs/data/mlflow.yaml
@@ -44,7 +44,7 @@ spec:
   catalogRef:
     name: data-engineering
   scmConnectionRef:
-    name: plural  # you'll need to add this ScmConnection manually before this is functional
+    name: github  # you'll need to add this ScmConnection manually before this is functional
   title: "Setting up mlflow on cluster {{ context.cluster }} for {{ context.cloud }}"
   message: |
     Set up mlflow on {{ context.cluster }} ({{ context.cloud }})

--- a/setup/catalogs/devops/grafana.yaml
+++ b/setup/catalogs/devops/grafana.yaml
@@ -30,7 +30,6 @@ spec:
   title: "Grafana setup ({{ context.cluster }})"
   message: |
     Sets up Grafana on {{ context.cluster }} cluster.
-  identifier: pluralsh/plrl-dev-aws # FIXME
   configuration:
   - name: cluster
     type: STRING

--- a/setup/catalogs/devops/grafana.yaml
+++ b/setup/catalogs/devops/grafana.yaml
@@ -26,7 +26,7 @@ spec:
   catalogRef:
     name: devops
   scmConnectionRef:
-    name: plural # you'll need to add this ScmConnection manually before this is functional
+    name: github # you'll need to add this ScmConnection manually before this is functional
   title: "Grafana setup ({{ context.cluster }})"
   message: |
     Sets up Grafana on {{ context.cluster }} cluster.

--- a/setup/catalogs/devops/kubecost.yaml
+++ b/setup/catalogs/devops/kubecost.yaml
@@ -30,7 +30,6 @@ spec:
   title: "Kubecost setup ({{ context.cluster }})"
   message: |
     Sets up Kubecost on {{ context.cluster }} cluster.
-  identifier: pluralsh/plrl-dev-aws # FIXME
   configuration:
   - name: cluster
     type: STRING

--- a/setup/catalogs/devops/kubecost.yaml
+++ b/setup/catalogs/devops/kubecost.yaml
@@ -26,7 +26,7 @@ spec:
   catalogRef:
     name: devops
   scmConnectionRef:
-    name: plural # you'll need to add this ScmConnection manually before this is functional
+    name: github # you'll need to add this ScmConnection manually before this is functional
   title: "Kubecost setup ({{ context.cluster }})"
   message: |
     Sets up Kubecost on {{ context.cluster }} cluster.

--- a/setup/catalogs/infra/cluster-eks.yaml
+++ b/setup/catalogs/infra/cluster-eks.yaml
@@ -26,7 +26,7 @@ spec:
   catalogRef:
     name: infra
   scmConnectionRef:
-    name: plural  # you'll need to add this ScmConnection manually before this is functional
+    name: github  # you'll need to add this ScmConnection manually before this is functional
   title: "Adding EKS cluster: {{ context.name }}"
   message: "Adding EKS cluster {{ context.name }} and registering it with Plural"
   configuration:

--- a/setup/catalogs/security/gatekeeper.yaml
+++ b/setup/catalogs/security/gatekeeper.yaml
@@ -28,7 +28,7 @@ spec:
   catalogRef:
     name: security
   scmConnectionRef:
-    name: plural  # you'll need to add this ScmConnection manually before this is functional
+    name: github  # you'll need to add this ScmConnection manually before this is functional
   title: Gatekeeper setup
   message: Sets up Gatekeeper, policy bundle and a set of constraints.
   configuration:

--- a/setup/catalogs/security/trivy-operator.yaml
+++ b/setup/catalogs/security/trivy-operator.yaml
@@ -22,6 +22,6 @@ spec:
   catalogRef:
     name: security
   scmConnectionRef:
-    name: plural  # you'll need to add this ScmConnection manually before this is functional
+    name: github  # you'll need to add this ScmConnection manually before this is functional
   title: Trivy Operator setup
   message: Sets up Trivy Operator.


### PR DESCRIPTION
Also renamed default scm connection from `plural` to `github` as it is used in a lot of other places by default.