### PR TITLE
feat: add basic helm examples

### DIFF
--- a/examples/helm-basic-with-inline-values/cluster.yaml
+++ b/examples/helm-basic-with-inline-values/cluster.yaml
@@ -1,0 +1,7 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: Cluster
+metadata:
+  name: mgmt
+  namespace: examples
+spec:
+  handle: mgmt

--- a/examples/helm-basic-with-inline-values/servicedeployment.yaml
+++ b/examples/helm-basic-with-inline-values/servicedeployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: ServiceDeployment
+metadata:
+  name: plrl-01-grafana
+  namespace: examples
+spec:
+  helm:
+    url: https://grafana.github.io/helm-charts
+    chart: grafana
+    version: x.x.x
+    values:
+      ingress:
+        enabled: true
+        annotations:
+          cert-manager.io/cluster-issuer: plural
+        ingressClassName: nginx
+        hosts:
+          - grafana-test.plrl-dev-aws.onplural.sh
+        tls:
+          - hosts:
+              - grafana-test.plrl-dev-aws.onplural.sh
+            secretName: grafana-tls
+  clusterRef:
+    kind: Cluster
+    name: mgmt
+    namespace: examples

--- a/examples/helm-basic-with-inline-values/servicedeployment.yaml
+++ b/examples/helm-basic-with-inline-values/servicedeployment.yaml
@@ -15,10 +15,10 @@ spec:
           cert-manager.io/cluster-issuer: plural
         ingressClassName: nginx
         hosts:
-          - grafana-test.plrl-dev-aws.onplural.sh
+          - grafana-test.your-domain.com
         tls:
           - hosts:
-              - grafana-test.plrl-dev-aws.onplural.sh
+              - grafana-test.your-domain.com
             secretName: grafana-tls
   clusterRef:
     kind: Cluster

--- a/examples/helm-basic-with-values-file/cluster.yaml
+++ b/examples/helm-basic-with-values-file/cluster.yaml
@@ -1,0 +1,7 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: Cluster
+metadata:
+  name: mgmt
+  namespace: examples
+spec:
+  handle: mgmt

--- a/examples/helm-basic-with-values-file/gitrepository.yaml
+++ b/examples/helm-basic-with-values-file/gitrepository.yaml
@@ -1,0 +1,7 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: GitRepository
+metadata:
+  name: example
+  namespace: examples
+spec:
+  url: git@github.com:<your_example_repository>.git

--- a/examples/helm-basic-with-values-file/helm-values/plrl-02-grafana.yaml
+++ b/examples/helm-basic-with-values-file/helm-values/plrl-02-grafana.yaml
@@ -1,0 +1,13 @@
+ingress:
+  enabled: true
+  annotations:
+    cert-manager.io/cluster-issuer: plural
+  ingressClassName: nginx
+
+  hosts:
+    - grafana-test.plrl-dev-aws.onplural.sh
+
+  tls:
+    - hosts:
+        - grafana-test.plrl-dev-aws.onplural.sh
+      secretName: grafana-tls

--- a/examples/helm-basic-with-values-file/helm-values/plrl-02-grafana.yaml
+++ b/examples/helm-basic-with-values-file/helm-values/plrl-02-grafana.yaml
@@ -5,9 +5,9 @@ ingress:
   ingressClassName: nginx
 
   hosts:
-    - grafana-test.plrl-dev-aws.onplural.sh
+    - grafana-test.your-domain.com
 
   tls:
     - hosts:
-        - grafana-test.plrl-dev-aws.onplural.sh
+        - grafana-test.your-domain.com
       secretName: grafana-tls

--- a/examples/helm-basic-with-values-file/helm-values/plrl-02-grafana.yaml.liquid
+++ b/examples/helm-basic-with-values-file/helm-values/plrl-02-grafana.yaml.liquid
@@ -5,9 +5,9 @@ ingress:
   ingressClassName: nginx
 
   hosts:
-    - grafana-test.your-domain.com
+    - {{ configuration.host }}
 
   tls:
     - hosts:
-        - grafana-test.your-domain.com
+        - {{ configuration.host }}
       secretName: grafana-tls

--- a/examples/helm-basic-with-values-file/servicedeployment.yaml
+++ b/examples/helm-basic-with-values-file/servicedeployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: ServiceDeployment
+metadata:
+  name: plrl-02-grafana
+  namespace: examples
+spec:
+  repositoryRef:
+    kind: GitRepository
+    name: example
+    namespace: examples
+  git:
+    folder: helm-values
+    ref: main
+  helm:
+    url: https://grafana.github.io/helm-charts
+    chart: grafana
+    version: x.x.x
+    valuesFiles:
+      - plrl-02-grafana.yaml
+  clusterRef:
+    kind: Cluster
+    name: mgmt
+    namespace: examples

--- a/examples/helm-basic-with-values-file/servicedeployment.yaml
+++ b/examples/helm-basic-with-values-file/servicedeployment.yaml
@@ -16,7 +16,9 @@ spec:
     chart: grafana
     version: x.x.x
     valuesFiles:
-      - plrl-02-grafana.yaml
+      - plrl-02-grafana.yaml.liquid
+  configuration:
+    host: 'grafana-test.your-domain.com'
   clusterRef:
     kind: Cluster
     name: mgmt


### PR DESCRIPTION
- basic helm chart via service deployment with inline helm values
- basic helm chart via service deployment with a values file referenced from git

[Docs PR](https://github.com/pluralsh/documentation/pull/451)