### PR TITLE
Update Gatekeeper chart to 3.22.2

### DIFF
--- a/catalogs/security/gatekeeper/gatekeeper.yaml
+++ b/catalogs/security/gatekeeper/gatekeeper.yaml
@@ -9,5 +9,5 @@ spec:
     namespace: policy
     helm:
       url: https://open-policy-agent.github.io/gatekeeper/charts
-      version: 3.15.1
+      version: 3.22.2
       chart: gatekeeper


### PR DESCRIPTION
## Summary

- Updates the Gatekeeper service catalog chart from `3.15.1` to `3.22.2`.
- Uses the current latest stable Gatekeeper Helm chart from `https://open-policy-agent.github.io/gatekeeper/charts`.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file("catalogs/security/gatekeeper/gatekeeper.yaml"); puts "yaml ok"'`
- `git diff --check`
- `/private/tmp/plural-cli-0.12.50/plural pr contracts --file /private/tmp/gatekeeper-contract/contracts.yaml`

The temporary Plural contract used `bundle: policy-essentials-v2022` and rendered:

- `documentation/gatekeeper/README.md`
- `bootstrap/apps/gatekeeper/gatekeeper.yaml`
- `bootstrap/apps/gatekeeper/gatekeeper-constraints.yaml`
- `bootstrap/apps/gatekeeper/gatekeeper-policy-bundle.yaml`

Not run: repository `just test`, because `just` is not installed in this environment. The existing checked-in `test/contracts.yaml` currently fails in the Plural CLI with `error unmarshaling JSON: while decoding JSON: invalid syntax` before rendering the existing Airbyte contract.
