### PR TITLE
Update AWS load balancer controller chart

### DIFF
--- a/catalogs/network/aws-load-balancer-controller/globalservice.yaml
+++ b/catalogs/network/aws-load-balancer-controller/globalservice.yaml
@@ -10,7 +10,7 @@ spec:
     namespace: kube-system
     protect: true # protect prevents deletion in the UI, but also tunes the cluster drain behavior to leave this service in-place which can help w/ cleanup
     helm:
-      version: "1.8.2"
+      version: "1.8.4"
       chart: aws-load-balancer-controller
       url: https://aws.github.io/eks-charts
       valuesFiles:


### PR DESCRIPTION
## Summary

- update the AWS Load Balancer Controller Helm chart from 1.8.2 to 1.8.4
- keep the existing chart line; upstream chart metadata maps 1.8.4 to appVersion v2.8.3
- verified the Plural automation renders with the updated chart version

## Verification

- `python3 -c "import pathlib, yaml; [yaml.safe_load(path.read_text()) for path in pathlib.Path('catalogs/network/aws-load-balancer-controller').glob('*.yaml')]"`
- `git diff --check HEAD~1`
- `/private/tmp/plural-cli-0.12.50/plural pr contracts --file /private/tmp/aws-lbc-contract/contracts.yaml`

The local Plural contract render produced:

- `bootstrap/components/aws-load-balancer-controller.yaml`
- `catalogs/network/aws-load-balancer-controller/globalservice.yaml`
- `catalogs/network/aws-load-balancer-controller/helm/loadbalancer.yaml.liquid`
- `helm/loadbalancer.yaml.liquid`

Note: `just test` was not available in this environment. The checked-in `test/contracts.yaml` currently fails locally in the Plural CLI JSON unmarshalling path before rendering the existing Airbyte contract, so I verified this PR with a focused contract that exercises the AWS Load Balancer Controller automation directly.
