### PR TITLE
Add Kyverno catalog scaffold

### DIFF
--- a/catalogs/security/kyverno/README.md
+++ b/catalogs/security/kyverno/README.md
@@ -1,0 +1,7 @@
+# Kyverno
+
+This is a baseline Kyverno installation using Plural.
+
+## Contributing
+
+If there are any features or documentation you'd like to add to this setup, please feel free to contribute back at https://github.com/pluralsh/scaffolds.

--- a/catalogs/security/kyverno/kyverno.yaml
+++ b/catalogs/security/kyverno/kyverno.yaml
@@ -1,0 +1,13 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: GlobalService
+metadata:
+  name: kyverno
+  namespace: apps
+spec:
+  template:
+    name: kyverno
+    namespace: kyverno
+    helm:
+      url: https://kyverno.github.io/kyverno/
+      chart: kyverno
+      version: 3.8.0

--- a/setup/catalogs/security/kyverno.yaml
+++ b/setup/catalogs/security/kyverno.yaml
@@ -1,0 +1,29 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: PrAutomation
+metadata:
+  name: kyverno
+spec:
+  name: kyverno
+  icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
+  identifier: mgmt
+  documentation: Sets up Kyverno policy engine.
+  creates:
+    git:
+      ref: main
+      folder: catalogs/security/kyverno
+    templates:
+      - source: README.md
+        destination: documentation/kyverno/README.md
+        external: true
+      - source: kyverno.yaml
+        destination: bootstrap/apps/kyverno/kyverno.yaml
+        external: true
+  repositoryRef:
+    name: scaffolds
+  catalogRef:
+    name: security
+  scmConnectionRef:
+    name: plural  # you'll need to add this ScmConnection manually before this is functional
+  title: Kyverno setup
+  message: Sets up Kyverno policy engine.
+  configuration: []


### PR DESCRIPTION
## Summary

- Adds a Kyverno entry to the security catalog.
- Adds a baseline Kyverno `GlobalService` using the official Kyverno Helm chart `3.8.0` / app version `v1.18.0`.
- Adds a matching `PrAutomation` so the scaffold can render README documentation and the Kyverno bootstrap manifest.

## Verification

- `ruby -e 'require "yaml"; %w[catalogs/security/kyverno/kyverno.yaml setup/catalogs/security/kyverno.yaml].each { |p| YAML.load_file(p); puts "#{p} ok" }'`
- `git diff --check`
- `plural pr contracts --file <focused Kyverno contract>`

The focused Plural contract rendered:

- `documentation/kyverno/README.md`
- `bootstrap/apps/kyverno/kyverno.yaml`

Also checked `just test`; it currently fails before this scaffold is rendered because the checked-in `test/contracts.yaml` hits `error unmarshaling JSON: while decoding JSON: invalid syntax` while processing an existing contract.
