### PR TITLE
Add Falco catalog scaffold

### DIFF
--- a/catalogs/security/falco/README.md
+++ b/catalogs/security/falco/README.md
@@ -1,0 +1,7 @@
+# Falco
+
+This is a baseline Falco installation using Plural.
+
+## Contributing
+
+If there are any features or documentation you'd like to add to this setup, please feel free to contribute back at https://github.com/pluralsh/scaffolds.

--- a/catalogs/security/falco/falco.yaml
+++ b/catalogs/security/falco/falco.yaml
@@ -1,0 +1,13 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: GlobalService
+metadata:
+  name: falco
+  namespace: apps
+spec:
+  template:
+    name: falco
+    namespace: falco
+    helm:
+      url: https://falcosecurity.github.io/charts
+      chart: falco
+      version: 8.0.3

--- a/setup/catalogs/security/falco.yaml
+++ b/setup/catalogs/security/falco.yaml
@@ -1,0 +1,29 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: PrAutomation
+metadata:
+  name: falco
+spec:
+  name: falco
+  icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/falco/horizontal/color/falco-horizontal-color.svg
+  identifier: mgmt
+  documentation: Sets up Falco runtime security.
+  creates:
+    git:
+      ref: main
+      folder: catalogs/security/falco
+    templates:
+      - source: README.md
+        destination: documentation/falco/README.md
+        external: true
+      - source: falco.yaml
+        destination: bootstrap/apps/falco/falco.yaml
+        external: true
+  repositoryRef:
+    name: scaffolds
+  catalogRef:
+    name: security
+  scmConnectionRef:
+    name: plural  # you'll need to add this ScmConnection manually before this is functional
+  title: Falco setup
+  message: Sets up Falco runtime security.
+  configuration: []


### PR DESCRIPTION
## Summary

- Adds a Falco entry to the security catalog.
- Adds a baseline Falco `GlobalService` using the official Falco Helm chart `8.0.3` / app version `0.43.1`.
- Adds a matching `PrAutomation` so the scaffold can render README documentation and the Falco bootstrap manifest.

## Verification

- `ruby -e 'require "yaml"; %w[catalogs/security/falco/falco.yaml setup/catalogs/security/falco.yaml].each { |p| YAML.load_file(p); puts "#{p} ok" }'`
- `git diff --check`
- `plural pr contracts --file <focused Falco contract>`

The focused Plural contract rendered:

- `documentation/falco/README.md`
- `bootstrap/apps/falco/falco.yaml`

Also checked `just test`; it currently fails before this scaffold is rendered because the checked-in `test/contracts.yaml` hits `error unmarshaling JSON: while decoding JSON: invalid syntax` while processing an existing contract.
