### PR TITLE
Add External Secrets catalog scaffold

### DIFF
--- a/catalogs/security/external-secrets/README.md
+++ b/catalogs/security/external-secrets/README.md
@@ -1,0 +1,7 @@
+# External Secrets Operator
+
+This is a baseline External Secrets Operator installation using Plural.
+
+## Contributing
+
+If there are any features or documentation you'd like to add to this setup, please feel free to contribute back at https://github.com/pluralsh/scaffolds.

--- a/catalogs/security/external-secrets/external-secrets.yaml
+++ b/catalogs/security/external-secrets/external-secrets.yaml
@@ -1,0 +1,13 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: GlobalService
+metadata:
+  name: external-secrets
+  namespace: apps
+spec:
+  template:
+    name: external-secrets
+    namespace: external-secrets
+    helm:
+      url: https://charts.external-secrets.io
+      chart: external-secrets
+      version: 2.4.1

--- a/setup/catalogs/security/external-secrets.yaml
+++ b/setup/catalogs/security/external-secrets.yaml
@@ -1,0 +1,29 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: PrAutomation
+metadata:
+  name: external-secrets
+spec:
+  name: external-secrets
+  icon: https://raw.githubusercontent.com/external-secrets/external-secrets/main/assets/eso-logo-large.png
+  identifier: mgmt
+  documentation: Sets up External Secrets Operator.
+  creates:
+    git:
+      ref: main
+      folder: catalogs/security/external-secrets
+    templates:
+      - source: README.md
+        destination: documentation/external-secrets/README.md
+        external: true
+      - source: external-secrets.yaml
+        destination: bootstrap/apps/external-secrets/external-secrets.yaml
+        external: true
+  repositoryRef:
+    name: scaffolds
+  catalogRef:
+    name: security
+  scmConnectionRef:
+    name: plural  # you'll need to add this ScmConnection manually before this is functional
+  title: External Secrets Operator setup
+  message: Sets up External Secrets Operator.
+  configuration: []


### PR DESCRIPTION
## Summary

- add a baseline External Secrets Operator catalog scaffold
- add a PR automation that renders the README and GlobalService into a Plural bootstrap repo
- use the official External Secrets Helm chart at version 2.4.1

## Verification

- `ruby -e "require 'yaml'; ARGV.each { |p| YAML.load_file(p) }" catalogs/security/external-secrets/external-secrets.yaml setup/catalogs/security/external-secrets.yaml`
- `git diff --cached --check`
- `/private/tmp/plural-cli-0.12.50/plural pr contracts --file /private/tmp/external-secrets-contract/contracts.yaml`

The local Plural contract render produced:

- `documentation/external-secrets/README.md`
- `bootstrap/apps/external-secrets/external-secrets.yaml`

Upstream chart metadata verified from `external-secrets/external-secrets`:

- chart: `external-secrets`
- version: `2.4.1`
- appVersion: `v2.4.1`
- icon: `https://raw.githubusercontent.com/external-secrets/external-secrets/main/assets/eso-logo-large.png`
