### PR TITLE
Update ExternalDNS chart to 9.0.3

### DIFF
--- a/catalogs/network/externaldns/globalservice.yaml
+++ b/catalogs/network/externaldns/globalservice.yaml
@@ -22,7 +22,7 @@ spec:
       name: infra # this should point to your `plural up` repo
       namespace: infra
     helm:
-      version: 8.3.8
+      version: 9.0.3
       chart: external-dns
       url: oci://registry-1.docker.io/bitnamicharts
       valuesFiles:


### PR DESCRIPTION
## Summary

- update the ExternalDNS Bitnami chart used by the network catalog from 8.3.8 to 9.0.3

## Verification

- Confirmed the existing Plural values surface still exists in the current Bitnami values:
  - `provider`
  - `txtOwnerId`
  - `policy`
  - `domainFilters`
  - `serviceAccount.annotations`
  - `serviceAccount.labels`
- Rendered the focused Plural PR contract for the ExternalDNS automation with `cloud=aws` and `dnsZone=example.com`:
  - `/private/tmp/plural-cli-0.12.50/plural pr contracts --file /private/tmp/external-dns-contract/contracts.yaml`
- Confirmed the rendered GlobalService uses chart version `9.0.3`.
- Parsed the rendered bootstrap YAML successfully with Ruby YAML.
- `git diff --check`
