### PR TITLE
Add KEDA catalog scaffold

### DIFF
--- a/catalogs/devops/keda/README.md
+++ b/catalogs/devops/keda/README.md
@@ -1,0 +1,7 @@
+# KEDA
+
+This is a baseline KEDA installation using Plural.
+
+## Contributing
+
+If there are any features or documentation you'd like to add to this setup, please feel free to contribute back at https://github.com/pluralsh/scaffolds.

--- a/catalogs/devops/keda/keda.yaml
+++ b/catalogs/devops/keda/keda.yaml
@@ -1,0 +1,13 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: GlobalService
+metadata:
+  name: keda
+  namespace: apps
+spec:
+  template:
+    name: keda
+    namespace: keda
+    helm:
+      url: https://kedacore.github.io/charts
+      chart: keda
+      version: 2.19.0

--- a/setup/catalogs/devops/keda.yaml
+++ b/setup/catalogs/devops/keda.yaml
@@ -1,0 +1,29 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: PrAutomation
+metadata:
+  name: keda
+spec:
+  name: keda
+  icon: https://raw.githubusercontent.com/kedacore/keda/main/images/keda-logo-500x500-white.png
+  identifier: mgmt
+  documentation: Sets up KEDA event-driven autoscaling.
+  creates:
+    git:
+      ref: main
+      folder: catalogs/devops/keda
+    templates:
+      - source: README.md
+        destination: documentation/keda/README.md
+        external: true
+      - source: keda.yaml
+        destination: bootstrap/apps/keda/keda.yaml
+        external: true
+  repositoryRef:
+    name: scaffolds
+  catalogRef:
+    name: devops
+  scmConnectionRef:
+    name: plural  # you'll need to add this ScmConnection manually before this is functional
+  title: KEDA setup
+  message: Sets up KEDA event-driven autoscaling.
+  configuration: []


### PR DESCRIPTION
## Summary

- add a baseline KEDA catalog scaffold under the devops catalog
- render the official KEDA chart as a global service using chart version 2.19.0

## Verification

- Confirmed the official KEDA Helm repository index lists `keda` chart version `2.19.0`.
- Parsed the new scaffold YAML files with Ruby YAML.
- Rendered the focused Plural PR contract for the KEDA automation:
  - `/private/tmp/plural-cli-0.12.50/plural pr contracts --file /private/tmp/keda-contract/contracts.yaml`
- Confirmed the rendered files include:
  - `documentation/keda/README.md`
  - `bootstrap/apps/keda/keda.yaml`
- `git diff --check`
