### PR TITLE
Update n8n chart to 2.0.1

### DIFF
--- a/catalogs/data/n8n/helm/n8n.yaml.liquid
+++ b/catalogs/data/n8n/helm/n8n.yaml.liquid
@@ -1,34 +1,29 @@
 {% raw %}
-n8n:
-  encryption_key: {{ imports[configuration.stackName].encryption_key }}
-
-config:
-  database:
-    type: postgresdb
-    postgresdb:
-      host: {{ imports[configuration.stackName].postgres_host }}
-      port: 5432
-      database: n8n
-      user: n8n
-      password: {{ imports[configuration.stackName].postgres_password }}
-
-scaling:
-  enabled: false
-
-postgresql:
-  enabled: false
-
-redis:
-  enabled: false
-
 main:
-  extraEnv:
-    N8N_EDITOR_BASE_URL: "https://{{ configuration.hostname }}"
-    WEBHOOK_URL: "https://{{ configuration.hostname }}/"
-    N8N_USER_MANAGEMENT_DISABLED: "false"
-    N8N_DIAGNOSTICS_ENABLED: "false"
-    N8N_HIRING_BANNER_ENABLED: "false"
-    N8N_PERSONALIZATION_ENABLED: "false"
+  secret:
+    n8n:
+      encryption_key: {{ imports[configuration.stackName].encryption_key }}
+    db:
+      postgresdb:
+        password: {{ imports[configuration.stackName].postgres_password }}
+  config:
+    db:
+      type: postgresdb
+      postgresdb:
+        host: {{ imports[configuration.stackName].postgres_host }}
+        port: 5432
+        database: n8n
+        user: n8n
+    n8n:
+      editor_base_url: "https://{{ configuration.hostname }}"
+      user_management_disabled: "false"
+      diagnostics_enabled: "false"
+      hiring_banner_enabled: "false"
+      personalization_enabled: "false"
+    webhook_url: "https://{{ configuration.hostname }}/"
+  service:
+    type: ClusterIP
+    port: 5678
 
 ingress:
   enabled: true

--- a/catalogs/data/n8n/n8n-servicedeployment.yaml
+++ b/catalogs/data/n8n/n8n-servicedeployment.yaml
@@ -16,7 +16,7 @@ spec:
     name: infra
     namespace: infra
   helm:
-    version: "1.4.1"
+    version: "2.0.1"
     chart: n8n
     release: n8n
     ignoreHooks: false


### PR DESCRIPTION
## Summary

- update the n8n Helm chart from 1.4.1 to 2.0.1
- migrate values to the current 8gears chart schema under `main.config` and `main.secret`
- keep PostgreSQL, encryption key, ingress, and service port behavior equivalent under the new chart

## Verification

- Rendered the upstream 8gears/n8n Helm chart v2.0.1 locally with equivalent placeholder values using `helm template`.
- Confirmed the rendered output includes `DB_TYPE`, `DB_POSTGRESDB_*`, `N8N_ENCRYPTION_KEY`, `N8N_EDITOR_BASE_URL`, `WEBHOOK_URL`, and service/ingress port `5678`.
- Checked `just test`; it currently fails before this scaffold is rendered because the checked-in `test/contracts.yaml` hits `error unmarshaling JSON: while decoding JSON: invalid syntax` while processing an existing contract.
