### PR TITLE
chore(gatekeeper): update Helm chart to 3.23.0

### DIFF
--- a/catalogs/security/gatekeeper/gatekeeper.yaml
+++ b/catalogs/security/gatekeeper/gatekeeper.yaml
@@ -9,5 +9,5 @@ spec:
     namespace: policy
     helm:
       url: https://open-policy-agent.github.io/gatekeeper/charts
-      version: 3.15.1
+      version: 3.23.0
       chart: gatekeeper


### PR DESCRIPTION
## Summary

- update the OPA Gatekeeper Helm chart from `3.15.1` to `3.23.0`
- bring the security catalog scaffold onto the current stable Gatekeeper release

## Validation

- `helm lint gatekeeper-3.23.0.tgz`
- `helm template gatekeeper gatekeeper-3.23.0.tgz --namespace policy` (21 rendered documents)

The scaffold does not override chart values, so the update remains limited to the chart version.