### PR TITLE
feat(catalog): add production-oriented Kestra onboarding

### DIFF
--- a/catalogs/data/kestra/README.md
+++ b/catalogs/data/kestra/README.md
@@ -1,0 +1,64 @@
+# Plural Kestra
+
+This catalog installs a production-oriented Kestra Open Source baseline on AWS, Azure, or Google Cloud. It provisions durable infrastructure and configures the official Kestra Helm chart with:
+
+- PostgreSQL 14 for the Kestra queue and repository
+- S3, Azure Blob Storage, or Google Cloud Storage for internal object storage
+- workload identity for object-storage access; no static cloud credentials are written to Git
+- native Kestra basic authentication initialized before the first public request
+- a generated 256-bit encryption key for `SECRET` inputs and outputs
+- NGINX ingress with TLS issued by cert-manager
+
+The catalog defaults to a single Kestra standalone pod. The database and object storage are durable, but the application tier is not highly available. Split-component or multi-replica deployments should be designed and load-tested for the expected workload before production use.
+
+## Prerequisites
+
+- Plural service contexts for the target cluster and network
+- NGINX Ingress Controller and cert-manager with a `letsencrypt-prod` ClusterIssuer
+- AWS EKS Pod Identity, GKE Workload Identity, or Azure Workload Identity enabled on the target cluster
+- an existing Azure Storage account in the cluster resource group with hierarchical namespace disabled when deploying to Azure
+- network and DNS access from the target AKS cluster to the Azure Blob endpoint
+- an existing GCP Private Service Access connection for `servicenetworking.googleapis.com`, with sufficient unallocated address space, managed by the platform network stack
+- DNS for the selected hostname pointed at the ingress controller
+
+## Configuration
+
+| Parameter | Description |
+| --- | --- |
+| `cluster` | Target Plural cluster handle |
+| `cloud` | Cloud provider: `aws`, `azure`, or `gcp` |
+| `hostname` | DNS hostname for the Kestra UI and API |
+| `adminEmail` | Valid email address for the initial Kestra administrator |
+| `storageBucket` | Globally unique S3/GCS bucket name, or container name unique within the Azure Storage account |
+| `region` | AWS region for the infrastructure stack; AWS only |
+| `storageAccount` | Existing Azure Storage account; Azure only |
+| `maxUploadSize` | Maximum request body accepted by NGINX; defaults to `100m` |
+| `enableDockerRunner` | Enables Kestra's privileged rootless Docker-in-Docker sidecar; defaults to `false` |
+
+## Security model
+
+Terraform generates the database password, administrator password, and Kestra encryption key. They are marked sensitive in stack outputs and materialized in the cluster as the `kestra-secrets` Secret. The Git repository contains only runtime import expressions, not plaintext credentials.
+
+The generated administrator password is available from the `admin_password` output of the `kestra-<cluster>` infrastructure stack. Treat Terraform state and Kubernetes Secret access as privileged because both contain runtime credentials.
+
+Cloud storage permissions are scoped to the selected bucket or container:
+
+- AWS: list/location permissions on the bucket and read/write/delete permissions on its objects
+- GCP: `roles/storage.objectAdmin` on the bucket
+- Azure: Storage Blob Data Contributor on the container
+
+The catalog consumes the existing GCP Private Service Access connection but does not create or modify it. Keeping that shared connection in the platform network stack prevents application stacks from replacing one another's allocated peering ranges.
+
+Docker-in-Docker is disabled by default because it requires a privileged sidecar. Enable it only when workflows need Docker-based script tasks and the cluster security policy permits privileged containers.
+
+## Operations
+
+The default pod request follows Kestra's minimum standalone sizing: 2 vCPU and 4 GiB of memory. Review application sizing, database sizing, backup retention, deletion protection, and object-storage lifecycle policy for the intended workload.
+
+AWS and GCP enable database deletion protection by default. Azure relies on Infrastructure Stack approval because Flexible Server does not expose the same catalog-level deletion-protection control; review every Azure destroy plan carefully.
+
+The Helm version tracks Kestra's `1.3.x` LTS line. Test upgrades in a non-production environment and follow Kestra's database migration guidance before promoting them.
+
+## Contributing
+
+Improvements are welcome at https://github.com/pluralsh/scaffolds.

--- a/catalogs/data/kestra/helm/kestra.yaml.liquid
+++ b/catalogs/data/kestra/helm/kestra.yaml.liquid
@@ -1,0 +1,117 @@
+{% raw %}
+fullnameOverride: kestra
+
+common:
+  replicas: 1
+  resources:
+    requests:
+      cpu: "2"
+      memory: 4Gi
+    limits:
+      memory: 8Gi
+  {% if configuration.cloud == 'azure' %}
+  podLabels:
+    azure.workload.identity/use: "true"
+  {% endif %}
+
+serviceAccount:
+  create: true
+  automount: true
+  name: "{{ imports[configuration.stackName].service_account_name }}"
+  {% if configuration.cloud == 'gcp' %}
+  annotations:
+    iam.gke.io/gcp-service-account: "{{ imports[configuration.stackName].gcp_service_account_email }}"
+  {% elsif configuration.cloud == 'azure' %}
+  annotations:
+    azure.workload.identity/client-id: "{{ imports[configuration.stackName].azure_client_id }}"
+  {% endif %}
+
+deployments:
+  standalone:
+    dind:
+      enabled: {{ configuration.enableDockerRunner }}
+
+dind:
+  enabled: {{ configuration.enableDockerRunner }}
+  mode: rootless
+  socketPath: /dind
+  tmpPath: /tmp
+
+configurations:
+  application:
+    datasources:
+      postgres:
+        url: "jdbc:postgresql://{{ imports[configuration.stackName].postgres_host }}:5432/kestra?sslmode=require"
+        driver-class-name: org.postgresql.Driver
+        username: kestra
+    kestra:
+      queue:
+        type: postgres
+      repository:
+        type: postgres
+      url: "https://{{ configuration.hostname }}"
+      storage:
+        {% if configuration.cloud == 'aws' %}
+        type: s3
+        s3:
+          bucket: "{{ imports[configuration.stackName].storage_bucket_name }}"
+          region: "{{ configuration.region }}"
+        {% elsif configuration.cloud == 'gcp' %}
+        type: gcs
+        gcs:
+          bucket: "{{ imports[configuration.stackName].storage_bucket_name }}"
+          project-id: "{{ imports[configuration.stackName].project_id }}"
+        {% elsif configuration.cloud == 'azure' %}
+        type: azure
+        azure:
+          endpoint: "{{ imports[configuration.stackName].storage_account_endpoint }}"
+          container: "{{ imports[configuration.stackName].storage_bucket_name }}"
+          workload-identity-client-id: "{{ imports[configuration.stackName].azure_client_id }}"
+        {% endif %}
+  secrets:
+    - name: kestra-secrets
+      key: application-secrets.yml
+
+extraManifests:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: kestra-secrets
+      labels:
+        app.kubernetes.io/name: kestra
+        app.kubernetes.io/part-of: kestra
+    type: Opaque
+    stringData:
+      application-secrets.yml: |
+        datasources:
+          postgres:
+            password: "{{ imports[configuration.stackName].postgres_password }}"
+        kestra:
+          encryption:
+            secret-key: "{{ imports[configuration.stackName].encryption_key }}"
+          server:
+            basic-auth:
+              username: "{{ configuration.adminEmail }}"
+              password: "{{ imports[configuration.stackName].admin_password }}"
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ configuration.maxUploadSize }}"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+  hosts:
+    - host: "{{ configuration.hostname }}"
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: kestra-tls
+      hosts:
+        - "{{ configuration.hostname }}"
+{% endraw %}

--- a/catalogs/data/kestra/kestra-servicedeployment.yaml
+++ b/catalogs/data/kestra/kestra-servicedeployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: ServiceDeployment
+metadata:
+  name: kestra-{{ context.cluster }}
+  namespace: apps
+spec:
+{% if context.ai %}
+  agentId: {{ context.ai.session.agent_id }}
+{% endif %}
+  namespace: kestra
+  git:
+    folder: helm/kestra/{{ context.cluster }}
+    ref: main
+  repositoryRef:
+    kind: GitRepository
+    name: infra
+    namespace: infra
+  helm:
+    url: https://helm.kestra.io/
+    version: "1.3.x"
+    chart: kestra
+    release: kestra
+    valuesFiles:
+      - kestra.yaml.liquid
+  imports:
+    - stackRef:
+        name: kestra-{{ context.cluster }}
+        namespace: apps
+  configuration:
+    cluster: "{{ context.cluster }}"
+    cloud: "{{ context.cloud }}"
+    hostname: "{{ context.hostname }}"
+    adminEmail: "{{ context.adminEmail }}"
+    maxUploadSize: "{{ context.maxUploadSize }}"
+    enableDockerRunner: {{ context.enableDockerRunner }}
+    stackName: "kestra-{{ context.cluster }}"
+    {% if context.cloud == 'aws' %}
+    region: "{{ context.region }}"
+    {% endif %}
+  clusterRef:
+    kind: Cluster
+    name: "{{ context.cluster }}"
+    namespace: infra

--- a/catalogs/data/kestra/kestra-stack.yaml
+++ b/catalogs/data/kestra/kestra-stack.yaml
@@ -1,0 +1,32 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: InfrastructureStack
+metadata:
+  name: kestra-{{ context.cluster }}
+  namespace: apps
+spec:
+{% if context.ai %}
+  agentId: {{ context.ai.session.agent_id }}
+{% endif %}
+  detach: false
+  type: TERRAFORM
+  approval: true
+  manageState: true
+  actor: console@plural.sh
+  git:
+    ref: main
+    folder: terraform/apps/kestra/{{ context.cluster }}
+  repositoryRef:
+    name: infra
+    namespace: infra
+  variables:
+    storage_bucket: "{{ context.storageBucket }}"
+  {% if context.cloud == 'azure' %}
+  jobSpec:
+    namespace: plrl-deploy-operator
+    labels:
+      azure.workload.identity/use: "true"
+    serviceAccount: stacks
+  {% endif %}
+  clusterRef:
+    name: mgmt
+    namespace: infra

--- a/catalogs/data/kestra/terraform/aws/bucket.tf
+++ b/catalogs/data/kestra/terraform/aws/bucket.tf
@@ -1,0 +1,32 @@
+resource "aws_s3_bucket" "kestra" {
+  bucket        = var.storage_bucket
+  force_destroy = var.force_destroy_bucket
+  tags          = local.tags
+}
+
+resource "aws_s3_bucket_public_access_block" "kestra" {
+  bucket = aws_s3_bucket.kestra.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "kestra" {
+  bucket = aws_s3_bucket.kestra.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "kestra" {
+  bucket = aws_s3_bucket.kestra.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}

--- a/catalogs/data/kestra/terraform/aws/iam.tf
+++ b/catalogs/data/kestra/terraform/aws/iam.tf
@@ -1,0 +1,60 @@
+resource "aws_iam_role" "kestra" {
+  name = local.resource_name
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowEksPodIdentity"
+        Effect = "Allow"
+        Principal = {
+          Service = "pods.eks.amazonaws.com"
+        }
+        Action = [
+          "sts:AssumeRole",
+          "sts:TagSession",
+        ]
+      },
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_policy" "kestra_storage" {
+  name_prefix = "${local.resource_name}-storage-"
+  description = "Least-privilege access to Kestra internal storage"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "BucketMetadata"
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket", "s3:GetBucketLocation"]
+        Resource = aws_s3_bucket.kestra.arn
+      },
+      {
+        Sid      = "ObjectAccess"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = "${aws_s3_bucket.kestra.arn}/*"
+      },
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "kestra_storage" {
+  role       = aws_iam_role.kestra.name
+  policy_arn = aws_iam_policy.kestra_storage.arn
+}
+
+resource "aws_eks_pod_identity_association" "kestra" {
+  cluster_name    = local.cluster_name
+  namespace       = local.service_account_namespace
+  service_account = local.service_account_name
+  role_arn        = aws_iam_role.kestra.arn
+
+  depends_on = [aws_iam_role_policy_attachment.kestra_storage]
+}

--- a/catalogs/data/kestra/terraform/aws/locals.tf
+++ b/catalogs/data/kestra/terraform/aws/locals.tf
@@ -1,0 +1,28 @@
+data "plural_cluster" "cluster" {
+  handle = var.cluster_handle
+}
+
+locals {
+  tags = data.plural_cluster.cluster.tags
+  tier = var.cluster_handle == "mgmt" ? "plural" : try(lookup(local.tags, "tier", "dev"), "dev")
+}
+
+data "plural_service_context" "network" {
+  name = "plrl/vpc/${local.tier}"
+}
+
+data "plural_service_context" "cluster" {
+  name = "plrl/clusters/${var.cluster_handle}"
+}
+
+locals {
+  network_context           = jsondecode(data.plural_service_context.network.configuration)
+  cluster_context           = jsondecode(data.plural_service_context.cluster.configuration)
+  cluster_name              = local.cluster_context.cluster_name
+  subnet_ids                = local.network_context.subnet_ids
+  vpc_id                    = local.network_context.vpc_id
+  vpc_cidr                  = local.network_context.vpc_cidr
+  resource_name             = trim(substr(replace(lower("${local.cluster_name}-kestra"), "/[^a-z0-9-]/", "-"), 0, 63), "-")
+  service_account_namespace = "kestra"
+  service_account_name      = "kestra"
+}

--- a/catalogs/data/kestra/terraform/aws/outputs.tf
+++ b/catalogs/data/kestra/terraform/aws/outputs.tf
@@ -1,0 +1,32 @@
+output "storage_bucket_name" {
+  description = "S3 bucket used for Kestra internal storage."
+  value       = aws_s3_bucket.kestra.bucket
+}
+
+output "service_account_name" {
+  description = "Kubernetes service account associated with EKS Pod Identity."
+  value       = local.service_account_name
+}
+
+output "postgres_host" {
+  description = "Private RDS hostname."
+  value       = module.database.db_instance_address
+}
+
+output "postgres_password" {
+  description = "Generated Kestra database password."
+  value       = random_password.database.result
+  sensitive   = true
+}
+
+output "admin_password" {
+  description = "Generated password for the initial Kestra administrator."
+  value       = random_password.admin.result
+  sensitive   = true
+}
+
+output "encryption_key" {
+  description = "Generated 256-bit Kestra encryption key, encoded as base64."
+  value       = random_id.encryption_key.b64_std
+  sensitive   = true
+}

--- a/catalogs/data/kestra/terraform/aws/postgres.tf
+++ b/catalogs/data/kestra/terraform/aws/postgres.tf
@@ -1,0 +1,76 @@
+module "database_security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
+
+  name        = "${local.resource_name}-db"
+  description = "PostgreSQL access for Kestra from the cluster VPC"
+  vpc_id      = local.vpc_id
+
+  ingress_with_cidr_blocks = [
+    {
+      from_port   = 5432
+      to_port     = 5432
+      protocol    = "tcp"
+      description = "PostgreSQL from the cluster VPC"
+      cidr_blocks = local.vpc_cidr
+    },
+  ]
+
+  tags = local.tags
+}
+
+module "database" {
+  source  = "terraform-aws-modules/rds/aws"
+  version = "~> 6.3"
+
+  identifier = local.resource_name
+
+  engine               = "postgres"
+  engine_version       = var.postgres_version
+  family               = "postgres${var.postgres_version}"
+  major_engine_version = var.postgres_version
+  instance_class       = var.db_instance_class
+
+  allocated_storage     = var.db_storage
+  max_allocated_storage = var.db_max_storage
+  storage_encrypted     = true
+
+  db_name                     = "kestra"
+  username                    = "kestra"
+  password                    = random_password.database.result
+  manage_master_user_password = false
+  port                        = 5432
+
+  maintenance_window              = "Mon:00:00-Mon:03:00"
+  backup_window                   = "03:00-06:00"
+  backup_retention_period         = var.backup_retention_period
+  enabled_cloudwatch_logs_exports = ["postgresql"]
+  create_cloudwatch_log_group     = true
+
+  monitoring_interval                   = 30
+  monitoring_role_name                  = "${substr(local.resource_name, 0, 40)}-rds-monitoring"
+  create_monitoring_role                = true
+  performance_insights_enabled          = true
+  performance_insights_retention_period = 7
+
+  apply_immediately = true
+  multi_az          = var.multi_az
+
+  create_db_subnet_group = true
+  subnet_ids             = local.subnet_ids
+  vpc_security_group_ids = [module.database_security_group.security_group_id]
+
+  parameters = [
+    {
+      name  = "autovacuum"
+      value = "1"
+    },
+    {
+      name  = "client_encoding"
+      value = "utf8"
+    },
+  ]
+
+  deletion_protection = var.deletion_protection
+  tags                = local.tags
+}

--- a/catalogs/data/kestra/terraform/aws/providers.tf
+++ b/catalogs/data/kestra/terraform/aws/providers.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.25, < 7.0"
+    }
+    plural = {
+      source  = "pluralsh/plural"
+      version = ">= 0.2.9"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6, < 4.0"
+    }
+  }
+}
+
+provider "plural" {}
+
+provider "aws" {
+  region = var.region
+}

--- a/catalogs/data/kestra/terraform/aws/secrets.tf
+++ b/catalogs/data/kestra/terraform/aws/secrets.tf
@@ -1,0 +1,19 @@
+resource "random_password" "database" {
+  length      = 32
+  min_lower   = 1
+  min_numeric = 1
+  min_upper   = 1
+  special     = false
+}
+
+resource "random_password" "admin" {
+  length      = 32
+  min_lower   = 1
+  min_numeric = 1
+  min_upper   = 1
+  special     = false
+}
+
+resource "random_id" "encryption_key" {
+  byte_length = 32
+}

--- a/catalogs/data/kestra/terraform/aws/variables.tf
+++ b/catalogs/data/kestra/terraform/aws/variables.tf
@@ -1,0 +1,65 @@
+variable "cluster_handle" {
+  type        = string
+  description = "Plural handle of the target Kubernetes cluster."
+  default     = "{{ context.cluster }}"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region for the Kestra infrastructure."
+  default     = "{{ context.region }}"
+}
+
+variable "storage_bucket" {
+  type        = string
+  description = "Globally unique S3 bucket for Kestra internal storage."
+  default     = "{{ context.storageBucket }}"
+}
+
+variable "postgres_version" {
+  type        = string
+  description = "PostgreSQL major version supported by Kestra."
+  default     = "14"
+}
+
+variable "db_instance_class" {
+  type        = string
+  description = "RDS instance class for the Kestra database."
+  default     = "db.t4g.large"
+}
+
+variable "db_storage" {
+  type        = number
+  description = "Initial RDS storage in GiB."
+  default     = 20
+}
+
+variable "db_max_storage" {
+  type        = number
+  description = "Maximum RDS autoscaled storage in GiB."
+  default     = 100
+}
+
+variable "backup_retention_period" {
+  type        = number
+  description = "Number of days to retain RDS backups."
+  default     = 7
+}
+
+variable "multi_az" {
+  type        = bool
+  description = "Whether to run RDS in a Multi-AZ configuration."
+  default     = true
+}
+
+variable "deletion_protection" {
+  type        = bool
+  description = "Protect the RDS instance from accidental deletion."
+  default     = true
+}
+
+variable "force_destroy_bucket" {
+  type        = bool
+  description = "Allow Terraform to delete a non-empty storage bucket."
+  default     = false
+}

--- a/catalogs/data/kestra/terraform/azure/bucket.tf
+++ b/catalogs/data/kestra/terraform/azure/bucket.tf
@@ -1,0 +1,21 @@
+data "azurerm_resource_group" "cluster" {
+  name = local.resource_group_name
+}
+
+data "azurerm_storage_account" "kestra" {
+  name                = var.storage_account_name
+  resource_group_name = data.azurerm_resource_group.cluster.name
+}
+
+resource "azurerm_storage_container" "kestra" {
+  name                  = var.storage_bucket
+  storage_account_id    = data.azurerm_storage_account.kestra.id
+  container_access_type = "private"
+
+  lifecycle {
+    precondition {
+      condition     = !data.azurerm_storage_account.kestra.is_hns_enabled
+      error_message = "Kestra internal storage requires an Azure Storage account with hierarchical namespace disabled."
+    }
+  }
+}

--- a/catalogs/data/kestra/terraform/azure/iam.tf
+++ b/catalogs/data/kestra/terraform/azure/iam.tf
@@ -1,0 +1,26 @@
+data "azurerm_kubernetes_cluster" "cluster" {
+  name                = local.cluster_name
+  resource_group_name = local.resource_group_name
+}
+
+resource "azurerm_user_assigned_identity" "kestra" {
+  name                = local.resource_name
+  resource_group_name = data.azurerm_resource_group.cluster.name
+  location            = data.azurerm_resource_group.cluster.location
+  tags                = local.tags
+}
+
+resource "azurerm_role_assignment" "kestra_storage" {
+  scope                = azurerm_storage_container.kestra.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.kestra.principal_id
+}
+
+resource "azurerm_federated_identity_credential" "kestra" {
+  name                = local.resource_name
+  resource_group_name = data.azurerm_resource_group.cluster.name
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = data.azurerm_kubernetes_cluster.cluster.oidc_issuer_url
+  parent_id           = azurerm_user_assigned_identity.kestra.id
+  subject             = "system:serviceaccount:${local.service_account_namespace}:${local.service_account_name}"
+}

--- a/catalogs/data/kestra/terraform/azure/locals.tf
+++ b/catalogs/data/kestra/terraform/azure/locals.tf
@@ -1,0 +1,36 @@
+data "plural_cluster" "cluster" {
+  handle = var.cluster_handle
+}
+
+locals {
+  tags = data.plural_cluster.cluster.tags
+  tier = var.cluster_handle == "mgmt" ? "plural" : try(lookup(local.tags, "tier", "dev"), "dev")
+}
+
+data "plural_service_context" "network" {
+  name = "plrl/network/${local.tier}"
+}
+
+data "plural_service_context" "cluster" {
+  name = "plrl/clusters/${var.cluster_handle}"
+}
+
+data "plural_service_context" "identity" {
+  name = "plrl/azure/identity"
+}
+
+locals {
+  network_context           = jsondecode(data.plural_service_context.network.configuration)
+  cluster_context           = jsondecode(data.plural_service_context.cluster.configuration)
+  identity_context          = jsondecode(data.plural_service_context.identity.configuration)
+  cluster_name              = local.cluster_context.cluster_name
+  resource_group_name       = local.cluster_context.resource_group_name
+  pg_subnet_id              = local.network_context.pg_subnet_id
+  dns_zone_id               = local.network_context.dns_zone_id
+  subscription_id           = local.identity_context.subscription_id
+  client_id                 = local.identity_context.client_id
+  tenant_id                 = local.identity_context.tenant_id
+  resource_name             = trim(substr(replace(lower("${local.cluster_name}-kestra"), "/[^a-z0-9-]/", "-"), 0, 55), "-")
+  service_account_namespace = "kestra"
+  service_account_name      = "kestra"
+}

--- a/catalogs/data/kestra/terraform/azure/outputs.tf
+++ b/catalogs/data/kestra/terraform/azure/outputs.tf
@@ -1,0 +1,47 @@
+output "storage_account_name" {
+  description = "Azure Storage account hosting Kestra internal storage."
+  value       = data.azurerm_storage_account.kestra.name
+}
+
+output "storage_account_endpoint" {
+  description = "Azure Blob service endpoint for Kestra internal storage."
+  value       = trimsuffix(data.azurerm_storage_account.kestra.primary_blob_endpoint, "/")
+}
+
+output "storage_bucket_name" {
+  description = "Azure Blob container used for Kestra internal storage."
+  value       = azurerm_storage_container.kestra.name
+}
+
+output "service_account_name" {
+  description = "Kubernetes service account linked through Azure Workload Identity."
+  value       = local.service_account_name
+}
+
+output "azure_client_id" {
+  description = "Client ID of the Kestra user-assigned identity."
+  value       = azurerm_user_assigned_identity.kestra.client_id
+}
+
+output "postgres_host" {
+  description = "Private Azure PostgreSQL hostname."
+  value       = azurerm_postgresql_flexible_server.kestra.fqdn
+}
+
+output "postgres_password" {
+  description = "Generated Kestra database password."
+  value       = random_password.database.result
+  sensitive   = true
+}
+
+output "admin_password" {
+  description = "Generated password for the initial Kestra administrator."
+  value       = random_password.admin.result
+  sensitive   = true
+}
+
+output "encryption_key" {
+  description = "Generated 256-bit Kestra encryption key, encoded as base64."
+  value       = random_id.encryption_key.b64_std
+  sensitive   = true
+}

--- a/catalogs/data/kestra/terraform/azure/postgres.tf
+++ b/catalogs/data/kestra/terraform/azure/postgres.tf
@@ -1,0 +1,34 @@
+resource "azurerm_postgresql_flexible_server" "kestra" {
+  name                          = "${local.resource_name}-${random_string.database_suffix.result}"
+  resource_group_name           = data.azurerm_resource_group.cluster.name
+  location                      = data.azurerm_resource_group.cluster.location
+  version                       = var.postgres_version
+  delegated_subnet_id           = local.pg_subnet_id
+  private_dns_zone_id           = local.dns_zone_id
+  administrator_login           = "kestra"
+  administrator_password        = random_password.database.result
+  public_network_access_enabled = false
+
+  storage_mb                   = var.db_storage_mb
+  auto_grow_enabled            = true
+  sku_name                     = var.db_sku
+  backup_retention_days        = var.backup_retention_days
+  geo_redundant_backup_enabled = false
+
+  high_availability {
+    mode = "ZoneRedundant"
+  }
+
+  lifecycle {
+    ignore_changes = [zone, high_availability[0].standby_availability_zone]
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_postgresql_flexible_server_database" "kestra" {
+  name      = "kestra"
+  server_id = azurerm_postgresql_flexible_server.kestra.id
+  collation = "en_US.utf8"
+  charset   = "utf8"
+}

--- a/catalogs/data/kestra/terraform/azure/providers.tf
+++ b/catalogs/data/kestra/terraform/azure/providers.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.0, < 5.0"
+    }
+    plural = {
+      source  = "pluralsh/plural"
+      version = ">= 0.2.9"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6, < 4.0"
+    }
+  }
+}
+
+provider "plural" {}
+
+provider "azurerm" {
+  features {}
+
+  use_cli              = false
+  use_oidc             = true
+  oidc_token_file_path = "/var/run/secrets/azure/tokens/azure-identity-token"
+  client_id            = local.client_id
+  subscription_id      = local.subscription_id
+  tenant_id            = local.tenant_id
+}

--- a/catalogs/data/kestra/terraform/azure/secrets.tf
+++ b/catalogs/data/kestra/terraform/azure/secrets.tf
@@ -1,0 +1,25 @@
+resource "random_password" "database" {
+  length      = 32
+  min_lower   = 1
+  min_numeric = 1
+  min_upper   = 1
+  special     = false
+}
+
+resource "random_password" "admin" {
+  length      = 32
+  min_lower   = 1
+  min_numeric = 1
+  min_upper   = 1
+  special     = false
+}
+
+resource "random_id" "encryption_key" {
+  byte_length = 32
+}
+
+resource "random_string" "database_suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}

--- a/catalogs/data/kestra/terraform/azure/variables.tf
+++ b/catalogs/data/kestra/terraform/azure/variables.tf
@@ -1,0 +1,41 @@
+variable "cluster_handle" {
+  type        = string
+  description = "Plural handle of the target Kubernetes cluster."
+  default     = "{{ context.cluster }}"
+}
+
+variable "storage_account_name" {
+  type        = string
+  description = "Existing Azure Storage account in the cluster resource group."
+  default     = "{{ context.storageAccount }}"
+}
+
+variable "storage_bucket" {
+  type        = string
+  description = "Azure Blob container for Kestra internal storage."
+  default     = "{{ context.storageBucket }}"
+}
+
+variable "postgres_version" {
+  type        = string
+  description = "Azure PostgreSQL Flexible Server major version supported by Kestra."
+  default     = "14"
+}
+
+variable "db_storage_mb" {
+  type        = number
+  description = "Initial PostgreSQL storage in MiB."
+  default     = 32768
+}
+
+variable "db_sku" {
+  type        = string
+  description = "Azure PostgreSQL Flexible Server SKU."
+  default     = "GP_Standard_D2s_v3"
+}
+
+variable "backup_retention_days" {
+  type        = number
+  description = "Number of days to retain PostgreSQL backups."
+  default     = 7
+}

--- a/catalogs/data/kestra/terraform/gcp/bucket.tf
+++ b/catalogs/data/kestra/terraform/gcp/bucket.tf
@@ -1,0 +1,17 @@
+resource "google_storage_bucket" "kestra" {
+  name                        = var.storage_bucket
+  project                     = local.project_id
+  location                    = local.region
+  force_destroy               = var.force_destroy_bucket
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "google_storage_bucket_iam_member" "kestra_objects" {
+  bucket = google_storage_bucket.kestra.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.kestra.email}"
+}

--- a/catalogs/data/kestra/terraform/gcp/db.tf
+++ b/catalogs/data/kestra/terraform/gcp/db.tf
@@ -1,0 +1,51 @@
+module "database" {
+  source  = "terraform-google-modules/sql-db/google//modules/postgresql"
+  version = "~> 25.2"
+
+  name                 = local.resource_name
+  random_instance_name = false
+  database_version     = var.database_version
+  project_id           = local.project_id
+  region               = local.region
+
+  edition           = "ENTERPRISE"
+  tier              = var.database_tier
+  availability_type = var.availability_type
+
+  maintenance_window_day          = 7
+  maintenance_window_hour         = 12
+  maintenance_window_update_track = "stable"
+  deletion_protection             = var.deletion_protection
+
+  database_flags = [
+    {
+      name  = "autovacuum"
+      value = "on"
+    },
+  ]
+
+  ip_configuration = {
+    ipv4_enabled    = false
+    private_network = data.google_compute_network.network.id
+    psc_enabled     = false
+    ssl_mode        = "ENCRYPTED_ONLY"
+  }
+
+  backup_configuration = {
+    enabled                        = true
+    start_time                     = "03:00"
+    location                       = null
+    point_in_time_recovery_enabled = true
+    transaction_log_retention_days = 7
+    retained_backups               = 7
+    retention_unit                 = "COUNT"
+  }
+
+  db_name      = "kestra"
+  db_charset   = "UTF8"
+  db_collation = "en_US.UTF8"
+
+  user_name            = "kestra"
+  user_password        = random_password.database.result
+  user_deletion_policy = "ABANDON"
+}

--- a/catalogs/data/kestra/terraform/gcp/iam.tf
+++ b/catalogs/data/kestra/terraform/gcp/iam.tf
@@ -1,0 +1,12 @@
+resource "google_service_account" "kestra" {
+  project      = local.project_id
+  account_id   = local.resource_name
+  display_name = "Kestra on ${local.cluster_name}"
+  description  = "Workload identity for Kestra internal storage"
+}
+
+resource "google_service_account_iam_member" "workload_identity" {
+  service_account_id = google_service_account.kestra.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${local.project_id}.svc.id.goog[${local.service_account_namespace}/${local.service_account_name}]"
+}

--- a/catalogs/data/kestra/terraform/gcp/locals.tf
+++ b/catalogs/data/kestra/terraform/gcp/locals.tf
@@ -1,0 +1,29 @@
+data "plural_cluster" "cluster" {
+  handle = var.cluster_handle
+}
+
+locals {
+  tags = data.plural_cluster.cluster.tags
+  tier = var.cluster_handle == "mgmt" ? "plural" : try(lookup(local.tags, "tier", "dev"), "dev")
+}
+
+data "plural_service_context" "network" {
+  name = "plrl/vpc/${local.tier}"
+}
+
+data "plural_service_context" "cluster" {
+  name = "plrl/clusters/${var.cluster_handle}"
+}
+
+locals {
+  network_context           = jsondecode(data.plural_service_context.network.configuration)
+  cluster_context           = jsondecode(data.plural_service_context.cluster.configuration)
+  project_id                = local.cluster_context.project_id
+  region                    = local.cluster_context.region
+  cluster_name              = local.cluster_context.cluster_name
+  network                   = local.network_context.network
+  network_short             = split("/", local.network)[length(split("/", local.network)) - 1]
+  resource_name             = trim(substr(replace(lower("${local.cluster_name}-kestra"), "/[^a-z0-9-]/", "-"), 0, 30), "-")
+  service_account_namespace = "kestra"
+  service_account_name      = "kestra"
+}

--- a/catalogs/data/kestra/terraform/gcp/network.tf
+++ b/catalogs/data/kestra/terraform/gcp/network.tf
@@ -1,0 +1,6 @@
+data "google_compute_network" "network" {
+  name    = local.network_short
+  project = local.project_id
+
+  depends_on = [data.plural_service_context.network]
+}

--- a/catalogs/data/kestra/terraform/gcp/outputs.tf
+++ b/catalogs/data/kestra/terraform/gcp/outputs.tf
@@ -1,0 +1,42 @@
+output "project_id" {
+  description = "GCP project hosting the Kestra infrastructure."
+  value       = local.project_id
+}
+
+output "storage_bucket_name" {
+  description = "GCS bucket used for Kestra internal storage."
+  value       = google_storage_bucket.kestra.name
+}
+
+output "service_account_name" {
+  description = "Kubernetes service account linked through GKE Workload Identity."
+  value       = local.service_account_name
+}
+
+output "gcp_service_account_email" {
+  description = "Google service account used by Kestra."
+  value       = google_service_account.kestra.email
+}
+
+output "postgres_host" {
+  description = "Private Cloud SQL address."
+  value       = module.database.private_ip_address
+}
+
+output "postgres_password" {
+  description = "Generated Kestra database password."
+  value       = random_password.database.result
+  sensitive   = true
+}
+
+output "admin_password" {
+  description = "Generated password for the initial Kestra administrator."
+  value       = random_password.admin.result
+  sensitive   = true
+}
+
+output "encryption_key" {
+  description = "Generated 256-bit Kestra encryption key, encoded as base64."
+  value       = random_id.encryption_key.b64_std
+  sensitive   = true
+}

--- a/catalogs/data/kestra/terraform/gcp/providers.tf
+++ b/catalogs/data/kestra/terraform/gcp/providers.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.10, < 8.0"
+    }
+    plural = {
+      source  = "pluralsh/plural"
+      version = ">= 0.2.9"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6, < 4.0"
+    }
+  }
+}
+
+provider "google" {}
+
+provider "plural" {}

--- a/catalogs/data/kestra/terraform/gcp/secrets.tf
+++ b/catalogs/data/kestra/terraform/gcp/secrets.tf
@@ -1,0 +1,19 @@
+resource "random_password" "database" {
+  length      = 32
+  min_lower   = 1
+  min_numeric = 1
+  min_upper   = 1
+  special     = false
+}
+
+resource "random_password" "admin" {
+  length      = 32
+  min_lower   = 1
+  min_numeric = 1
+  min_upper   = 1
+  special     = false
+}
+
+resource "random_id" "encryption_key" {
+  byte_length = 32
+}

--- a/catalogs/data/kestra/terraform/gcp/variables.tf
+++ b/catalogs/data/kestra/terraform/gcp/variables.tf
@@ -1,0 +1,41 @@
+variable "cluster_handle" {
+  type        = string
+  description = "Plural handle of the target Kubernetes cluster."
+  default     = "{{ context.cluster }}"
+}
+
+variable "storage_bucket" {
+  type        = string
+  description = "Globally unique GCS bucket for Kestra internal storage."
+  default     = "{{ context.storageBucket }}"
+}
+
+variable "database_version" {
+  type        = string
+  description = "Cloud SQL PostgreSQL version supported by Kestra."
+  default     = "POSTGRES_14"
+}
+
+variable "database_tier" {
+  type        = string
+  description = "Cloud SQL machine tier."
+  default     = "db-custom-2-7680"
+}
+
+variable "availability_type" {
+  type        = string
+  description = "Cloud SQL availability mode."
+  default     = "REGIONAL"
+}
+
+variable "deletion_protection" {
+  type        = bool
+  description = "Protect the Cloud SQL instance from accidental deletion."
+  default     = true
+}
+
+variable "force_destroy_bucket" {
+  type        = bool
+  description = "Allow Terraform to delete a non-empty storage bucket."
+  default     = false
+}

--- a/setup/catalogs/data/kestra.yaml
+++ b/setup/catalogs/data/kestra.yaml
@@ -1,0 +1,99 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: PrAutomation
+metadata:
+  name: kestra
+spec:
+  name: kestra
+  icon: https://kestra.io/favicon-192x192.png
+  identifier: mgmt
+  documentation: |
+    Sets up a production-oriented Kestra instance with managed PostgreSQL,
+    cloud object storage, workload identity, TLS, and native authentication.
+  creates:
+    git:
+      ref: main
+      folder: catalogs/data/kestra
+    templates:
+      - source: helm
+        destination: helm/kestra/{{ context.cluster }}
+        external: true
+      - source: "terraform/{{ context.cloud }}"
+        destination: terraform/apps/kestra/{{ context.cluster }}
+        external: true
+      - source: kestra-stack.yaml
+        destination: "bootstrap/apps/kestra/{{ context.cluster }}/kestra-stack.yaml"
+        external: true
+      - source: kestra-servicedeployment.yaml
+        destination: "bootstrap/apps/kestra/{{ context.cluster }}/kestra-servicedeployment.yaml"
+        external: true
+      - source: README.md
+        destination: documentation/kestra/README.md
+        external: true
+  repositoryRef:
+    name: scaffolds
+  catalogRef:
+    name: data-engineering
+  scmConnectionRef:
+    name: plural  # add this ScmConnection before using the automation
+  title: "Set up Kestra on {{ context.cluster }} ({{ context.cloud }})"
+  message: |
+    Sets up Kestra on {{ context.cluster }} with managed PostgreSQL, durable
+    object storage, workload identity, TLS, and generated administrator credentials.
+
+    Plural Service: mgmt/apps
+  configuration:
+    - name: cluster
+      type: CLUSTER
+      documentation: Handle of the cluster where Kestra will run.
+    - name: cloud
+      type: ENUM
+      documentation: Cloud provider for the Kestra infrastructure.
+      values:
+        - aws
+        - azure
+        - gcp
+    - name: hostname
+      type: STRING
+      documentation: DNS hostname for the Kestra UI and API.
+      validation:
+        regex: '^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$'
+    - name: adminEmail
+      type: STRING
+      documentation: Valid email address for the initial Kestra administrator.
+      validation:
+        regex: '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$'
+    - name: storageBucket
+      type: STRING
+      documentation: Globally unique S3/GCS bucket name, or container name unique within the Azure Storage account.
+      validation:
+        regex: '^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$'
+    - name: region
+      type: STRING
+      documentation: AWS region where Kestra infrastructure will be created.
+      optional: true
+      validation:
+        regex: '^[a-z]{2}(-[a-z]+)+-[0-9]$'
+      condition:
+        field: cloud
+        operation: EQ
+        value: aws
+    - name: storageAccount
+      type: STRING
+      documentation: Existing reachable Azure Storage account in the cluster resource group, with hierarchical namespace disabled.
+      optional: true
+      validation:
+        regex: '^[a-z0-9]{3,24}$'
+      condition:
+        field: cloud
+        operation: EQ
+        value: azure
+    - name: maxUploadSize
+      type: STRING
+      default: "100m"
+      documentation: Maximum request body accepted by the NGINX ingress, using k, m, or g units.
+      validation:
+        regex: '^[1-9][0-9]*(k|m|g)$'
+    - name: enableDockerRunner
+      type: BOOL
+      default: "false"
+      documentation: Enable the privileged rootless Docker-in-Docker sidecar for Docker-based script tasks.


### PR DESCRIPTION
## Summary

- add a self-service Kestra Open Source catalog onboarding for AWS, Azure, and GCP
- provision managed PostgreSQL 14 and durable cloud object storage
- use EKS Pod Identity, GKE Workload Identity, or Azure Workload Identity with storage-scoped permissions
- initialize native basic authentication and a persistent 256-bit encryption key from generated secrets
- provide TLS ingress with a bounded upload limit and keep privileged Docker-in-Docker opt-in

This gives catalog users a production-oriented Kestra baseline while clearly documenting that the default single-pod application tier is not highly available.

## Cloud behavior

- **AWS:** encrypted, Multi-AZ RDS; private VPC access; versioned S3; least-privilege Pod Identity
- **Azure:** private Flexible Server; HNS compatibility check for the existing Blob account; container-scoped role assignment; federated identity
- **GCP:** regional, private-only Cloud SQL; versioned GCS; bucket-scoped Workload Identity; consumes but does not mutate the platform-owned Private Service Access connection

## Validation

- `terraform fmt -check` and `terraform validate` for AWS, Azure, and GCP
- strict two-stage Liquid rendering for every cloud and the Docker-enabled branch
- Helm strict lint and template against the official Kestra chart `1.3.31`
- Plural PR automation rendering for AWS, Azure, and GCP contexts
- rendered-manifest assertions for storage selection, PostgreSQL, secrets, workload identity, TLS ingress, bounded uploads, and default-disabled Docker-in-Docker

No live cloud apply or end-to-end Kestra deployment was performed.

Closes pluralsh/plural-artifacts#812
